### PR TITLE
Add 12 hour time option for console output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 package-lock.json
 config/config.json
 utils/
+modules/consoleHelper/config.json

--- a/modules/consoleHelper.js
+++ b/modules/consoleHelper.js
@@ -1,10 +1,24 @@
-const chalk = require("chalk");
+const chalk = require("chalk"),
+fs = require("fs");
 
 // Defines the function of this module
 const MODULE_FUNCTION = "handle_console",
 
 // Base path for module folder creation and navigation
-BASE_PATH = null;
+BASE_PATH = "/consoleHelper";
+
+// Only ran on startup so using sync functions is fine
+// Makes the folders for files of the module
+if (!fs.existsSync(__dirname + BASE_PATH)) {
+    fs.mkdirSync(__dirname + BASE_PATH);
+    console.log(`[consoleHelper] Made consoleHelper module folder`);
+}
+if (!fs.existsSync(__dirname + BASE_PATH + "/config.json")) {
+    fs.writeFileSync(__dirname + BASE_PATH + "/config.json", JSON.stringify({"24hour":true}));
+    console.log(`[consoleHelper] Made consoleHelper config file`);
+}
+
+const config = require(__dirname + BASE_PATH + "/config.json");
 
 module.exports = {
     printInfo:function(emoji, s) {
@@ -21,7 +35,25 @@ module.exports = {
 
     getTime24:function() {
         const time = new Date();
-        return `${correctValue(time.getHours())}:${correctValue(time.getMinutes())}:${correctValue(time.getSeconds())}`
+        if (config["24hour"]) {
+            return `${correctValue(time.getHours())}:${correctValue(time.getMinutes())}:${correctValue(time.getSeconds())}`;
+        } else {
+            return this.t2412(`${correctValue(time.getHours())}:${correctValue(time.getMinutes())}:${correctValue(time.getSeconds())}`);
+        }
+    },
+
+    t2412:function(inp) {
+        if (parseInt(inp.split(":")[0]) > 11) {
+            const i = inp.split(":");
+            let i1 = parseInt(i[0]) - 12;
+            if (i1 == 0) i1 = 12;
+            return i1 + ":" + i[1] + " PM";
+        } else {
+            const i = inp.split(":");
+            let i1 = parseInt(i[0]);
+            if (i1 == 0) i1 = 12;
+            return i1 + ":" + i[1] + " AM";
+        }
     }
 }
 


### PR DESCRIPTION
This pr adds functionality to the consoleHelper that allows it to have it's own module folder and config to enable options for other time formats.
Resolves #6 