### PR TITLE
Fix mistakes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img height="150" src="http://ethanus.ml/images/Revolution.png">
 </h1>
 <h2 align="left">What is Revolution?</h2>
-<p align="left">Revolution is A modular Web framework, written in node.js , and built with the purpose of being a solid framework that apps can build upon to get up and running quickly and easily. Revolution is designed to make it easy to create the application you need, with no waste.
+<p align="left">Revolution is a modular web framework, written in node.js and built with the purpose of being a solid framework that apps can build upon to get up and running quickly and easily. Revolution is designed to make it easy to create the application you need, with no waste.
 </p>
 
 <h2 align="left">What is Revolution for?</h2>
@@ -10,7 +10,7 @@
 <h2 align="left">How does Revolution work?</h2>
 <p align="left">Revolution uses a set of modules to handle various functions, there are two modules included with the repo and builds, these being consoleHelper and example_request_handler. consoleHelper is a required module and as such the framework will not start without it, however example_request_handler can be removed without consequence and is there purely to help with module development.</p>
 <h2 align="left">How do modules work?</h2>
-<p align="left">Modules are loaded in at runtime and are completely separate from each other. Each module has a prefix, for example the request handlers have the prefix “handle_console”. These prefixes determine the function of the modules and help the server to function.</p>
+<p align="left">Modules are loaded in at runtime and are completely separate from each other. Each module has a prefix, for example the request handlers have the prefix “handle_requests” and the consoleHelper has the prefix of "handle_console". These prefixes help the server to determine the function of each module.</p>
 <h2 align="left">How to use Revolution.</h2>
 <h3 align="left">From source</h3>
 <p align="left">git clone https://github.com/tgpethan/Revolution.git<br>


### PR DESCRIPTION
Some mistakes made it through the review from the previous pr updating the readme from a few months ago.

Mistakes like request handlers being stated to have the prefix for the console helper.
Also just fixes some general capitalisation mistakes.