### PR TITLE
Sort out consoleHelper's Config formatting

### DIFF
--- a/modules/consoleHelper.js
+++ b/modules/consoleHelper.js
@@ -15,7 +15,7 @@ if (!fs.existsSync(__dirname + BASE_PATH)) {
 }
 // Creates the consoleHelper config file
 if (!fs.existsSync(__dirname + BASE_PATH + "/config.json")) {
-    fs.writeFileSync(__dirname + BASE_PATH + "/config.json", JSON.stringify({"24hour":true}));
+    fs.writeFileSync(__dirname + BASE_PATH + "/config.json", `{\n\t"24hour":true\n}`);
     console.log(`[consoleHelper] Made consoleHelper config file`);
 }
 


### PR DESCRIPTION
The consoleHelper has some pretty ugly formatting on the config, this fixes that.
**Before**
![nicememe ykfOU26gAWv0eqQ0VRw](https://user-images.githubusercontent.com/37120476/77670854-ab605100-6f7e-11ea-8bc3-e72c12e15499.png)
**After**
![nicememe yObC8LQ3OuXT08BsmGv](https://user-images.githubusercontent.com/37120476/77670937-c59a2f00-6f7e-11ea-804f-496c2e68db24.png)
